### PR TITLE
Add reportGeneratedTime to commits.json

### DIFF
--- a/frontend/src/types/zod/commits-type.ts
+++ b/frontend/src/types/zod/commits-type.ts
@@ -24,6 +24,7 @@ const authorFileTypeContributionsSchema = z.record(z.number());
 // Contains the zod validation schema for the commits.json file
 
 export const commitsSchema = z.object({
+  reportGeneratedTime: z.string(),
   authorDailyContributionsMap: z.record(z.array(authorDailyContributionsSchema)),
   authorFileTypeContributionMap: z.record(authorFileTypeContributionsSchema),
   authorContributionVariance: z.record(z.number()),

--- a/src/main/java/reposense/report/CommitReportJson.java
+++ b/src/main/java/reposense/report/CommitReportJson.java
@@ -16,6 +16,7 @@ import reposense.model.FileType;
  * Class that holds the data to be serialized into JSON format in `commits.json`.
  */
 public class CommitReportJson {
+    private final String reportGeneratedTime;
     private final Map<Author, List<AuthorDailyContribution>> authorDailyContributionsMap;
     private final Map<Author, LinkedHashMap<FileType, Integer>> authorFileTypeContributionMap;
     private final Map<Author, Float> authorContributionVariance;
@@ -26,6 +27,8 @@ public class CommitReportJson {
      */
     public CommitReportJson(String displayName) {
         Author emptyAuthor = Author.UNKNOWN_AUTHOR;
+
+        reportGeneratedTime = null;
 
         authorDailyContributionsMap = new HashMap<>();
         authorDailyContributionsMap.put(emptyAuthor, Collections.emptyList());
@@ -40,7 +43,9 @@ public class CommitReportJson {
         authorDisplayNameMap.put(emptyAuthor, displayName);
     }
 
-    public CommitReportJson(CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
+    public CommitReportJson(String reportGeneratedTime,
+                            CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
+        this.reportGeneratedTime = reportGeneratedTime;
         authorDailyContributionsMap = commitSummary.getAuthorDailyContributionsMap();
         authorFileTypeContributionMap = authorshipSummary.getAuthorFileTypeContributionMap();
         authorContributionVariance = commitSummary.getAuthorContributionVariance();

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -449,7 +449,9 @@ public class ReportGenerator {
         CommitContributionSummary commitSummary = commitsReporter.generateCommitSummary(config);
         earliestSinceDate = commitSummary.getEarliestSinceDate();
 
-        List<Path> generatedFiles = generateIndividualRepoReport(repoReportDirectory, commitSummary, authorshipSummary);
+        List<Path> generatedFiles = generateIndividualRepoReport(
+                formatter.format(ZonedDateTime.now(cliArguments.getZoneId())), repoReportDirectory,
+                commitSummary, authorshipSummary);
         logger.info(String.format(MESSAGE_COMPLETE_ANALYSIS, config.getLocation(), config.getBranch()));
         return generatedFiles;
     }
@@ -578,9 +580,10 @@ public class ReportGenerator {
      *
      * @return A list of paths to the JSON report files generated for this report.
      */
-    private List<Path> generateIndividualRepoReport(String repoReportDirectory,
+    private List<Path> generateIndividualRepoReport(String reportGeneratedTime, String repoReportDirectory,
             CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
-        CommitReportJson commitReportJson = new CommitReportJson(commitSummary, authorshipSummary);
+        CommitReportJson commitReportJson = new CommitReportJson(reportGeneratedTime,
+                commitSummary, authorshipSummary);
 
         List<Path> generatedFiles = new ArrayList<>();
         FileUtil.writeJsonFile(commitReportJson, getIndividualCommitsPath(repoReportDirectory))


### PR DESCRIPTION
commits.json does not show the time at which it was generated, unlike summary.json

Current commits.json:

`{"authorDailyContributionsMap":{"ongspxm":[],"jamessspanggg":[],"yamidark":[],"yong24s":[],"eugenepeh":[]},"authorFileTypeContributionMap":{"ongspxm":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"jamessspanggg":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"yamidark":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"yong24s":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"eugenepeh":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0}},"authorContributionVariance":{"ongspxm":0.0,"jamessspanggg":0.0,"yamidark":0.0,"yong24s":0.0,"eugenepeh":0.0},"authorDisplayNameMap":{"ongspxm":"Metta","jamessspanggg":"James","yamidark":"Jun An","yong24s":"Yong Hao","eugenepeh":"Eugene"}}`

A report generated time is now added to the commits.json

Example:

`{"reportGeneratedTime":"Sat, 14 Jun 2025 11:36:13 SGT","authorDailyContributionsMap":{"ongspxm":[],"jamessspanggg":[],"yamidark":[],"yong24s":[],"eugenepeh":[]},"authorFileTypeContributionMap":{"ongspxm":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"jamessspanggg":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"yamidark":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"yong24s":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0},"eugenepeh":{"gradle":0,"pug":0,"java":0,"js":0,"md":0,"scss":0,"yml":0}},"authorContributionVariance":{"ongspxm":0.0,"jamessspanggg":0.0,"yamidark":0.0,"yong24s":0.0,"eugenepeh":0.0},"authorDisplayNameMap":{"ongspxm":"Metta","jamessspanggg":"James","yamidark":"Jun An","yong24s":"Yong Hao","eugenepeh":"Eugene"}}`

This allows users to know when the commits.json file was generated, and possibly for developers to be able to troubleshoot bugs better 

Let's add a report generated time to the commits.json file