### PR TITLE
Add minimum lines of code feature

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -62,6 +62,7 @@ public class RepoSense {
             authorBlurbMap = cliArguments.getAuthorBlurbMap();
             chartBlurbMap = cliArguments.getChartBlurbMap();
 
+            RepoConfiguration.setMinLoc(configs, cliArguments.getNumMinLoc());
             RepoConfiguration.setFormatsToRepoConfigs(configs, cliArguments.getFormats());
             RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
             RepoConfiguration.setZoneIdToRepoConfigs(configs, cliArguments.getZoneId());

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -69,6 +70,7 @@ public class CommitInfoAnalyzer {
 
         return commitInfos.stream()
                 .map(commitInfo -> analyzeCommit(commitInfo, config))
+                .filter(Objects::nonNull)
                 .filter(commitResult -> !commitResult.getAuthor().equals(Author.UNKNOWN_AUTHOR)
                         && !CommitHash.isInsideCommitList(commitResult.getHash(), config.getIgnoreCommitList()))
                 .distinct()
@@ -113,8 +115,12 @@ public class CommitInfoAnalyzer {
             extractTagNames(tags);
         }
 
-        if (statLine.isEmpty()) { // empty commit, no files changed
+        if (statLine.isEmpty() && config.getMinLoc() < 0) { // empty commit, no files changed
             return new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle, messageBody, tags);
+        }
+
+        if (statLine.isEmpty() && config.getMinLoc() >= 0) { // empty commit, no files changed
+            return null;
         }
 
         String[] statInfos = statLine.split(NEW_LINE_SPLITTER);
@@ -122,8 +128,14 @@ public class CommitInfoAnalyzer {
         Map<FileType, ContributionPair> fileTypeAndContributionMap =
                 getFileTypesAndContribution(fileTypeContributions, config);
 
-        return new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle, messageBody, tags,
+        CommitResult commit = new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle, messageBody, tags,
                 fileTypeAndContributionMap);
+
+        if (commit.getInsertions() + commit.getDeletions() <= config.getMinLoc()) {
+            return null;
+        }
+
+        return commit;
     }
 
     /**

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -128,8 +128,8 @@ public class CommitInfoAnalyzer {
         Map<FileType, ContributionPair> fileTypeAndContributionMap =
                 getFileTypesAndContribution(fileTypeContributions, config);
 
-        CommitResult commit = new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle, messageBody, tags,
-                fileTypeAndContributionMap);
+        CommitResult commit = new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle,
+                messageBody, tags, fileTypeAndContributionMap);
 
         if (commit.getInsertions() + commit.getDeletions() <= config.getMinLoc()) {
             return null;

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -34,6 +34,7 @@ public class CliArguments {
     private boolean isFileSizeLimitIgnored;
     private int numCloningThreads;
     private int numAnalysisThreads;
+    private int numMinLoc;
     private ZoneId zoneId;
     private boolean isFindingPreviousAuthorsPerformed;
     private boolean isAuthorshipAnalyzed;
@@ -116,6 +117,10 @@ public class CliArguments {
 
     public int getNumAnalysisThreads() {
         return numAnalysisThreads;
+    }
+
+    public int getNumMinLoc() {
+        return numMinLoc;
     }
 
     public boolean isFindingPreviousAuthorsPerformed() {
@@ -393,6 +398,16 @@ public class CliArguments {
          */
         public Builder numAnalysisThreads(int numAnalysisThreads) {
             this.cliArguments.numAnalysisThreads = numAnalysisThreads;
+            return this;
+        }
+
+        /**
+         * Adds the {@code numMinLoc} to CliArguments.
+         *
+         * @param numMinLoc The number of lines of code to ignore.
+         */
+        public Builder numMinLoc(int numMinLoc) {
+            this.cliArguments.numMinLoc = numMinLoc;
             return this;
         }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -55,6 +55,7 @@ public class RepoConfiguration {
     private transient long fileSizeLimit = DEFAULT_FILE_SIZE_LIMIT;
     private transient boolean isFileSizeLimitOverriding = false;
     private transient boolean isIgnoredFileAnalysisSkipped = false;
+    private transient int minLoc = -1;
 
     private transient boolean hasUpdatedSinceDateInConfig = false;
 
@@ -684,6 +685,11 @@ public class RepoConfiguration {
         }
     }
 
+    public static void setMinLoc(List<RepoConfiguration> configs,
+                                                            int minLoc) {
+        configs.forEach(config -> config.setMinLoc(minLoc));
+    }
+
     /**
      * Checks if any of the {@code configs} is finding previous authors for commit analysis.
      */
@@ -1090,5 +1096,13 @@ public class RepoConfiguration {
 
     public AuthorConfiguration getAuthorConfig() {
         return authorConfig;
+    }
+
+    public void setMinLoc(int minLoc) {
+        this.minLoc = minLoc;
+    }
+
+    public int getMinLoc() {
+        return minLoc;
     }
 }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -685,11 +685,6 @@ public class RepoConfiguration {
         }
     }
 
-    public static void setMinLoc(List<RepoConfiguration> configs,
-                                                            int minLoc) {
-        configs.forEach(config -> config.setMinLoc(minLoc));
-    }
-
     /**
      * Checks if any of the {@code configs} is finding previous authors for commit analysis.
      */
@@ -1096,6 +1091,10 @@ public class RepoConfiguration {
 
     public AuthorConfiguration getAuthorConfig() {
         return authorConfig;
+    }
+
+    public static void setMinLoc(List<RepoConfiguration> configs, int minLoc) {
+        configs.forEach(config -> config.setMinLoc(minLoc));
     }
 
     public void setMinLoc(int minLoc) {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -322,6 +322,7 @@ public class ArgsParser {
         boolean isPortfolio = results.get(PORTFOLIO_FLAG[0]);
         int numCloningThreads = results.get(CLONING_THREADS_FLAG[0]);
         int numAnalysisThreads = results.get(ANALYSIS_THREADS_FLAG[0]);
+        int numMinLoc = results.get(FILTER_COMMIT_FLAG[0]);
         boolean shouldPerformFreshCloning = results.get(FRESH_CLONING_FLAG[0]);
         boolean shouldRefreshOnlyText = results.get(REFRESH_ONLY_TEXT_FLAG[0]);
 
@@ -339,6 +340,7 @@ public class ArgsParser {
                 .isFindingPreviousAuthorsPerformed(shouldFindPreviousAuthors)
                 .numCloningThreads(numCloningThreads)
                 .numAnalysisThreads(numAnalysisThreads)
+                .numMinLoc(numMinLoc)
                 .isAuthorshipAnalyzed(isAuthorshipAnalyzed)
                 .originalityThreshold(originalityThreshold)
                 .isPortfolio(isPortfolio)

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -79,6 +79,7 @@ public class ArgsParser {
     public static final String[] ORIGINALITY_THRESHOLD_FLAGS = new String[] {"--originality-threshold", "-ot"};
     public static final String[] PORTFOLIO_FLAG = new String[] {"--portfolio", "-P"};
     public static final String[] REFRESH_ONLY_TEXT_FLAG = new String[] {"--text", "-T"};
+    public static final String[] FILTER_COMMIT_FLAG = new String[]{"--filter-min-loc", "-fl"};
 
     private static final Logger logger = LogsManager.getLogger(ArgsParser.class);
 
@@ -269,6 +270,13 @@ public class ArgsParser {
                 .type(new AnalysisThreadsArgumentType())
                 .setDefault(DEFAULT_NUM_ANALYSIS_THREADS)
                 .help(FeatureControl.SUPPRESS);
+
+        parser.addArgument(FILTER_COMMIT_FLAG)
+                .dest(FILTER_COMMIT_FLAG[0])
+                .metavar("INT")
+                .type(Integer.class)
+                .setDefault(0)
+                .help("A flag to filter out commits that are less than or equal to the argument.");
 
         // Testing flags
         parser.addArgument(FRESH_CLONING_FLAG)

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -81,7 +81,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         List<CommitInfo> commitInfos = commitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> commitResults = commitInfoAnalyzer.analyzeCommits(commitInfos, config);
 
-        Assertions.assertEquals(commitInfos.size() - NUMBER_EUGENE_COMMIT - NUMBER_COMMIT_THREE_OR_LESS, commitResults.size());
+        Assertions.assertEquals(commitInfos.size() - NUMBER_EUGENE_COMMIT - NUMBER_COMMIT_THREE_OR_LESS,
+                commitResults.size());
     }
 
     @Test

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -31,6 +31,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
     private static final int NUMBER_EUGENE_COMMIT = 1;
     private static final int NUMBER_MINGYI_COMMIT = 1;
     private static final int NUMBER_EMPTY_MESSAGE_COMMIT = 1;
+    private static final int NUMBER_COMMIT_THREE_OR_LESS = 6;
     private static final FileType FILETYPE_JAVA = new FileType("java", Collections.singletonList("**java"));
     private static final FileType FILETYPE_MD = new FileType("md", Collections.singletonList("**md"));
     private static final FileType FILETYPE_TXT = new FileType("txt", Collections.singletonList("**txt"));
@@ -62,6 +63,31 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void analyzeCommits_fakeMainAuthorNoIgnoredCommitsNoDateRange_success() {
+        config.addAuthorNamesToAuthorMapEntry(new Author(MAIN_AUTHOR_NAME), MAIN_AUTHOR_NAME);
+        config.addAuthorNamesToAuthorMapEntry(new Author(FAKE_AUTHOR_NAME), FAKE_AUTHOR_NAME);
+
+        List<CommitInfo> commitInfos = commitInfoExtractor.extractCommitInfos(config);
+        List<CommitResult> commitResults = commitInfoAnalyzer.analyzeCommits(commitInfos, config);
+
+        Assertions.assertEquals(commitInfos.size() - NUMBER_EUGENE_COMMIT, commitResults.size());
+    }
+
+    @Test
+    public void analyzeCommits_retrieveAllWithoutMinCommits_success() {
+        config.setMinLoc(3);
+        config.addAuthorNamesToAuthorMapEntry(new Author(MAIN_AUTHOR_NAME), MAIN_AUTHOR_NAME);
+        config.addAuthorNamesToAuthorMapEntry(new Author(FAKE_AUTHOR_NAME), FAKE_AUTHOR_NAME);
+
+        List<CommitInfo> commitInfos = commitInfoExtractor.extractCommitInfos(config);
+        List<CommitResult> commitResults = commitInfoAnalyzer.analyzeCommits(commitInfos, config);
+
+        Assertions.assertEquals(commitInfos.size() - NUMBER_EUGENE_COMMIT - NUMBER_COMMIT_THREE_OR_LESS, commitResults.size());
+    }
+
+    @Test
+    public void analyzeCommits_retrieveAllWithoutMinCommitsLessThanZero_success() {
+        // In future iterations, an error message should be thrown for invalid numbers
+        config.setMinLoc(-1);
         config.addAuthorNamesToAuthorMapEntry(new Author(MAIN_AUTHOR_NAME), MAIN_AUTHOR_NAME);
         config.addAuthorNamesToAuthorMapEntry(new Author(FAKE_AUTHOR_NAME), FAKE_AUTHOR_NAME);
 

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -816,6 +816,16 @@ public class ArgsParserTest {
         Assertions.assertFalse(cliArguments.isOnlyTextRefreshed());
     }
 
+    @Test
+    public void parse_filterMinCommits_success() throws Exception {
+        String input = DEFAULT_INPUT_BUILDER
+                .addMinLoc(3)
+                .build();
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+
+        Assertions.assertEquals(3, cliArguments.getNumMinLoc());
+    }
+
     /**
      * Ensures that {@code actualSinceDate} is exactly one month before {@code untilDate}.
      *

--- a/src/test/java/reposense/util/InputBuilder.java
+++ b/src/test/java/reposense/util/InputBuilder.java
@@ -204,6 +204,11 @@ public class InputBuilder {
         return this;
     }
 
+    public InputBuilder addMinLoc(int loc) {
+        input.append(ArgsParser.FILTER_COMMIT_FLAG[0] + WHITESPACE + loc + WHITESPACE);
+        return this;
+    }
+
     /**
      * Adds the flag to enable shallow cloning.
      * This method should only be called once in one build.


### PR DESCRIPTION
### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
This is an implementation of a backend feature that adds a new CLI flag --filter-min-loc.

This aims to filter out commits with minimal changes. 

The goal is to reduce noise in the analysis and better reflect meaningful contributions.

The feature involves:

- Adding a new argument to CliArguments and ArgsParser
- Updating CommitInfoAnalyzer to discard commits where insertions and deletions fall below the threshold
- Updating RepoConguration to set the minimum line of code

An example of using this would be:

gradlew run -Dargs="--filter-min-loc 1"

This would block out any commits in which only 1 line (both insertions and deletions combined) was changed.
```

### Other information

### Without the additional flag:

<img width="950" alt="image" src="https://github.com/user-attachments/assets/6cbcf3f4-83d2-435e-8a15-e3a42d80effd" />

Insignificant commits are shown

### With the additional flag `--filter-min-loc 2`

<img width="952" alt="image" src="https://github.com/user-attachments/assets/9b20fd78-7ae1-4c66-a064-09f27f3a5bf5" />

Commits with equal to or less than 2 lines of edited code are no longer displayed
